### PR TITLE
CI complained about the missing requirement for php <= 5.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "require": {
-    "php": "<=5.5.0"
   },
   "require-dev": {
     "phpdocumentor/phpdocumentor": "2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "90fbda676cc1d8338a451eb6c2c89b3f",
+    "hash": "d0ade613c3dd92ff414d04c2e85e90a8",
     "packages": [],
     "packages-dev": [
         {
@@ -3511,8 +3511,6 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {
-        "php": "<=5.5.0"
-    },
+    "platform": [],
     "platform-dev": []
 }


### PR DESCRIPTION
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package php could not be found in any version, there may be a typo in the package name.
  Problem 2
    - The requested package php could not be found in any version, there may be a typo in the package name.
  Problem 3
    - phpmd/phpmd 2.2.0 requires php >=5.3.0 -> no matching package found.
    - phpmd/phpmd 2.2.0 requires php >=5.3.0 -> no matching package found.
    - Installation request for phpmd/phpmd 2.2.0 -> satisfiable by phpmd/phpmd[2.2.0].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.